### PR TITLE
Fix block names

### DIFF
--- a/src/main/java/dev/doublekekse/map_utils/registry/MapUtilsBlocks.java
+++ b/src/main/java/dev/doublekekse/map_utils/registry/MapUtilsBlocks.java
@@ -41,7 +41,7 @@ public class MapUtilsBlocks {
         if (shouldRegisterItem) {
             var itemKey = ResourceKey.create(Registries.ITEM, MapUtils.id(path));
 
-            var blockItem = new BlockItem(block, new Item.Properties().setId(itemKey));
+            var blockItem = new BlockItem(block, new Item.Properties().useBlockDescriptionPrefix().setId(itemKey));
             Registry.register(BuiltInRegistries.ITEM, itemKey, blockItem);
         }
 


### PR DESCRIPTION
Minecraft 1.21.2 caused new items, including `BlockItem`s, to automatically be registered with the `item.` translation key prefix. Block Items should now also use `useBlockDescriptionPrefix` in their `Item.Properties`, rather than be untranslated or have to add two translation keys for the same item.