### PR TITLE
Fix optionalFieldOf using null

### DIFF
--- a/src/main/java/dev/doublekekse/map_utils/command/ScheduleCommandExtension.java
+++ b/src/main/java/dev/doublekekse/map_utils/command/ScheduleCommandExtension.java
@@ -9,6 +9,8 @@ import net.minecraft.commands.CommandSourceStack;
 import net.minecraft.commands.arguments.TimeArgument;
 import net.minecraft.network.chat.Component;
 
+import java.util.Optional;
+
 import static net.minecraft.commands.Commands.argument;
 import static net.minecraft.commands.Commands.literal;
 
@@ -25,7 +27,7 @@ public class ScheduleCommandExtension {
                 var command = StringArgumentType.getString(context, "command");
                 var timerQueue = source.getServer().getWorldData().overworldData().getScheduledEvents();
 
-                timerQueue.schedule(command, worldTime, new CommandCallback(level.dimension(), entity == null ? null : entity.getUUID(), command, source.getPosition(), source.getRotation(), ((CommandSourceStackDuck) source).mapUtils$permissionLevel()));
+                timerQueue.schedule(command, worldTime, new CommandCallback(level.dimension(), entity == null ? Optional.empty() : Optional.of(entity.getUUID()), command, source.getPosition(), source.getRotation(), ((CommandSourceStackDuck) source).mapUtils$permissionLevel()));
 
                 source.sendSuccess(() -> Component.translatable("commands.map_utils.schedule.created.command", command, timeOffset, worldTime), true);
                 return 1;

--- a/src/main/java/dev/doublekekse/map_utils/timer/CommandCallback.java
+++ b/src/main/java/dev/doublekekse/map_utils/timer/CommandCallback.java
@@ -22,15 +22,16 @@ import net.minecraft.world.phys.Vec3;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import java.util.Optional;
 import java.util.UUID;
 
-public record CommandCallback(ResourceKey<Level> dimension, @Nullable UUID entityUUID,
+public record CommandCallback(ResourceKey<Level> dimension, @NotNull Optional<UUID> entityUUID,
                               String command, Vec3 position, Vec2 rotation,
                               int permissionLevel)
     implements TimerCallback<MinecraftServer> {
     public static final MapCodec<CommandCallback> CODEC = RecordCodecBuilder.mapCodec(instance -> instance.group(
             ResourceKey.codec(Registries.DIMENSION).fieldOf("dimension").forGetter(CommandCallback::dimension),
-            AdditionalCodecs.UUID_CODEC.optionalFieldOf("entity_uuid", null).forGetter(CommandCallback::entityUUID),
+            AdditionalCodecs.UUID_CODEC.optionalFieldOf("entity_uuid").forGetter(CommandCallback::entityUUID),
             Codec.STRING.fieldOf("command").forGetter(CommandCallback::command),
             Vec3.CODEC.fieldOf("position").forGetter(CommandCallback::position),
             Vec2.CODEC.fieldOf("rotation").forGetter(CommandCallback::rotation),
@@ -45,7 +46,7 @@ public record CommandCallback(ResourceKey<Level> dimension, @Nullable UUID entit
             // TODO
             return;
         }
-        var entity = entityUUID == null ? null : level.getEntity(entityUUID);
+        var entity = entityUUID.isEmpty() ? null : level.getEntity(entityUUID.get());
         minecraftServer.getCommands().performPrefixedCommand(createCommandSourceStack(entity, level), command);
     }
 


### PR DESCRIPTION
Passing null as the defaultValue causes major bugs when deserialising data; which in this case causes the level.dat to be unreadable.

It was easier logistically to just make the whole record use Optional.